### PR TITLE
Empty params_obj being passed into command

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## v0.1.3
+
+Fix bug with passing empty params_obj variable
+
 ## v0.1.2
 
 Fix bug with passing params through params_obj variable

--- a/actions/lib/bolt.py
+++ b/actions/lib/bolt.py
@@ -133,6 +133,9 @@ class BoltAction(Action):
         if kwargs.get('params_obj'):
             if not kwargs.get('params'):
                 kwargs['params'] = json.dumps(kwargs['params_obj'])
+
+        # Need to remove if exists to prevent dict from getting passed into the options
+        if "params_obj" in kwargs:
             del kwargs['params_obj']
 
         # parse all remaining arguments and options

--- a/pack.yaml
+++ b/pack.yaml
@@ -2,12 +2,12 @@
 ref: bolt
 name: bolt
 description: StackStorm integration pack for Puppet Bolt
-keywords: 
+keywords:
     - bolt
     - puppet
     - remote execution
     - configuration management
     - cfg management
-version: 0.1.2
+version: 0.1.3
 author: Encore Technologies
 email: code@encore.tech

--- a/tests/test_action_lib_bolt.py
+++ b/tests/test_action_lib_bolt.py
@@ -185,6 +185,15 @@ class TestActionLibBolt(BoltBaseActionTestCase):
 
     # Test that params doesn't get overwritten when params_obj is None
     @mock.patch("lib.bolt.json.dumps")
+    def test_build_options_args_params_obj_empty(self, mock_json_dumps):
+        action = self.get_action_instance({})
+        options, args = action.build_options_args(params_obj={})
+        self.assertEquals(args, [])
+        self.assertEquals(options, [])
+        assert not mock_json_dumps.called
+
+    # Test that params doesn't get overwritten when params_obj is None
+    @mock.patch("lib.bolt.json.dumps")
     def test_build_options_args_params_obj_none(self, mock_json_dumps):
         action = self.get_action_instance({})
         options, args = action.build_options_args(params_obj=None)


### PR DESCRIPTION
If a empty params_obj is passed into the action then it gets passed into the 'full_cmd' and causes the subprocess command to fail because it doesn't handle a dictionary.

error:
`TypeError: coercing to Unicode: need string or buffer, dict found`

before if we pass an empty params_obj:
```
kwargs: {u''tty'': None, u''verbose'': None, u''run_as'': None, u''configfile'': None, u''concurrency'': None, u''host_key_check'': False, u''query'': None, u''transport'': None, u''modulepath'': u''/test_path'', u''params'': None, u''tmpdir'': None, u''noop'': None, u''nodes'': u''winrm://test'', u''cwd'': None, u''private_key'': None, u''sudo_password'': None, u''description'': None, u''trace'': None, u''format'': u''json'', u''compile_concurrency'': None, u''ssl'': False, u''user'': None, u''ssl_verify'': False, u''credentials'': {}, u''params_obj'': {}, u''password'': None, u''cmd'': u''./bolt'', u''debug_'': None, u''connect_timeout'': None, u''boltdir'': None, u''sub_command'': u''plan run'', u''inventoryfile'': None, u''plan'': u''encore_rp::afg_windows_customizations''}

full command: [u''./bolt'', u''plan'', u''run'', ''--format'', u''json'', ''--no-host-key-check'', ''--modulepath'', u''/test_path'', ''--nodes'', u''winrm://test'', ''--no-ssl'', ''--no-ssl-verify'', {}, u''encore_rp::afg_windows_customizations'']
```

This is because `if kwargs.get('params_obj'):` returns False since the value is empty even though it exists so `del kwargs['params_obj']` never gets called and a empty dictionary gets passed to the command. 

To solve for this i added a check after the `if` to say if the params_obj exists then delete it. This accounts for the empty dictionary and a real value since if it has a real value the `if` would be called and it would be set to `params`.

after if we pass an empty params_obj:
```
kwargs: {u''tty'': None, u''verbose'': None, u''run_as'': None, u''configfile'': None, u''concurrency'': None, u''host_key_check'': False, u''query'': None, u''transport'': None, u''modulepath'': u''/test_path'', u''params'': None, u''tmpdir'': None, u''noop'': None, u''nodes'': u''winrm://test'', u''cwd'': None, u''private_key'': None, u''sudo_password'': None, u''description'': None, u''trace'': None, u''format'': u''json'', u''compile_concurrency'': None, u''ssl'': False, u''user'': None, u''ssl_verify'': False, u''credentials'': {}, u''password'': None, u''cmd'': u''./bolt'', u''debug_'': None, u''connect_timeout'': None, u''boltdir'': None, u''sub_command'': u''plan run'', u''inventoryfile'': None, u''plan'': u''encore_rp::afg_windows_customizations''}

full command: [u''./bolt'', u''plan'', u''run'', ''--format'', u''json'', ''--no-host-key-check'', ''--modulepath'', u''/test_path'', ''--nodes'', u''winrm://test'', ''--no-ssl'', ''--no-ssl-verify'', u''encore_rp::afg_windows_customizations'']
```